### PR TITLE
Adapt function to avoid a pandas 1 related error

### DIFF
--- a/rstoolbox/analysis/structure.py
+++ b/rstoolbox/analysis/structure.py
@@ -245,8 +245,10 @@ def secondary_structure_percentage( df, seqID, key_residues=None ):
     elif isinstance(df, DesignSeries):
         sse = list(df.get_structure(seqID, key_residues))
         csse = collections.Counter(sse)
-        dfp = df.append(pd.Series([float(csse['H']) / len(sse), float(csse['E']) / len(sse),
-                        float(csse['L']) / len(sse)], [H, E, L]))
+        dfp = copy.deepcopy(df)
+        dfp[H] = float(csse['H']) / len(sse)
+        dfp[E] = float(csse['E']) / len(sse)
+        dfp[L] = float(csse['L']) / len(sse)
         dfp.transfer_reference(df)
         return dfp
     else:


### PR DESCRIPTION
With pandas 1, the secondary_structure_percentage function raises an `AttributeError` related to the pd.merge step.
This is a simple hack to avoid this error

# Changes Proposed in this Pull Request:
- Remove an error related to pandas version

# Check List:

- [X] closes #xxxx
